### PR TITLE
Fix bug introduced by new react native version using 'strict' mode fo…

### DIFF
--- a/.babelignore
+++ b/.babelignore
@@ -1,0 +1,1 @@
+node_modules/firebase/lib/firebase-web.js

--- a/app/lib/orientation/orientationHandler.js
+++ b/app/lib/orientation/orientationHandler.js
@@ -1,5 +1,4 @@
-
-export default HANDLE_ORIENTATION = `
+const HANDLE_ORIENTATION = `
   <script>
 
     var degreeToRad = function( degree ) {
@@ -68,3 +67,5 @@ export default HANDLE_ORIENTATION = `
 
   </script>
 `;
+
+export default HANDLE_ORIENTATION;

--- a/app/lib/threejs/marker.js
+++ b/app/lib/threejs/marker.js
@@ -1,4 +1,4 @@
-export default THREE_RENDER_MARKER = `
+const THREE_RENDER_MARKER = `
   <script>
     var camera, scene, renderer;
     var frustum;
@@ -106,3 +106,5 @@ export default THREE_RENDER_MARKER = `
     }
   </script>
 `;
+
+export default THREE_RENDER_MARKER;

--- a/app/reducers/rootReducer.js
+++ b/app/reducers/rootReducer.js
@@ -1,7 +1,9 @@
 import { combineReducers } from 'redux';
 import pins from './reducer_pins';
 import recent from './reducer_recent.js';
-export default rootReducer = combineReducers({
+const rootReducer = combineReducers({
   pins,
   recent
 });
+
+export default rootReducer;


### PR DESCRIPTION
### Detail: 
1. In strict mode, you can't `export default` and assign it name ( `something = something`) at the same time—`export default` creates an exported variable called `default`.
2. Even though we had installed the same release (`0.21.0`), the semver settings in the `react-native` `package.json` allows for new versions of certain packages.
3. The new version of `babel-preset-react-native` institutes `'use strict'`.

:cry: 

### Fix:
1. Refactor non-compliant `export default`s.
2. Create `.babelignore` and add to it the `firebase-web` lib file, which had its own strict-mode issues.
3. Trust no one.

:+1: 