### PR TITLE
Removes swipe, introduces setState warning

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -39,7 +39,7 @@ const findAR = () => (
 const scenes = Actions.create(
   <Scene key="root" hideNavBar>
       <Scene initial key="login" component={Signin} />
-      <Scene key="view" component={ViewContainer} />
+      <Scene key="view" component={ViewContainer} type="replace" />
       <Scene key="friends" component={FriendList} />
   </Scene>
 );


### PR DESCRIPTION
This PR removes swiping back from the map view to the login page.

Unfortunately it also introduces an ugly warning about setState on unmounted components.

I have thoroughly tested our setStates by deleting all of them. It appears that the warning originates from the MapView imported from react-native-maps.

We will just have to decide which bug is uglier when deciding whether to merge this PR.